### PR TITLE
Update alicloud_cms_alarm deprecated settings

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,11 +40,34 @@ resource "alicloud_cms_alarm" "cpu_utilization" {
     instanceId = local.this_instance_id
     device     = "/dev/vda1,/dev/vdb1"
   }
-  statistics         = var.alarm_rule_statistics
+  dynamic "escalations_critical" {
+    for_each = var.alarm_escalation_level == "critical" ? [{}] : []
+    content {
+      statistics          = var.alarm_rule_statistics
+      comparison_operator = var.alarm_rule_comparison_operator
+      threshold           = var.alarm_rule_threshold
+      times               = var.alarm_rule_times
+    }
+  }
+  dynamic "escalations_warn" {
+    for_each = var.alarm_escalation_level == "warn" ? [{}] : []
+    content {
+      statistics          = var.alarm_rule_statistics
+      comparison_operator = var.alarm_rule_comparison_operator
+      threshold           = var.alarm_rule_threshold
+      times               = var.alarm_rule_times
+    }
+  }
+  dynamic "escalations_info" {
+    for_each = var.alarm_escalation_level == "info" ? [{}] : []
+    content {
+      statistics          = var.alarm_rule_statistics
+      comparison_operator = var.alarm_rule_comparison_operator
+      threshold           = var.alarm_rule_threshold
+      times               = var.alarm_rule_times
+    }
+  }
   period             = var.alarm_rule_period
-  operator           = var.alarm_rule_operator
-  threshold          = var.alarm_rule_threshold
-  triggered_count    = var.alarm_rule_triggered_count
   contact_groups     = var.alarm_rule_contact_groups
   silence_time       = var.alarm_rule_silence_time
   effective_interval = var.alarm_rule_effective_interval
@@ -59,11 +82,34 @@ resource "alicloud_cms_alarm" "memory_utilization" {
     instanceId = local.this_instance_id
     device     = "/dev/vda1,/dev/vdb1"
   }
-  statistics         = var.alarm_rule_statistics
+  dynamic "escalations_critical" {
+    for_each = var.alarm_escalation_level == "critical" ? [{}] : []
+    content {
+      statistics          = var.alarm_rule_statistics
+      comparison_operator = var.alarm_rule_comparison_operator
+      threshold           = var.alarm_rule_threshold
+      times               = var.alarm_rule_times
+    }
+  }
+  dynamic "escalations_warn" {
+    for_each = var.alarm_escalation_level == "warn" ? [{}] : []
+    content {
+      statistics          = var.alarm_rule_statistics
+      comparison_operator = var.alarm_rule_comparison_operator
+      threshold           = var.alarm_rule_threshold
+      times               = var.alarm_rule_times
+    }
+  }
+  dynamic "escalations_info" {
+    for_each = var.alarm_escalation_level == "info" ? [{}] : []
+    content {
+      statistics          = var.alarm_rule_statistics
+      comparison_operator = var.alarm_rule_comparison_operator
+      threshold           = var.alarm_rule_threshold
+      times               = var.alarm_rule_times
+    }
+  }
   period             = var.alarm_rule_period
-  operator           = var.alarm_rule_operator
-  threshold          = var.alarm_rule_threshold
-  triggered_count    = var.alarm_rule_triggered_count
   contact_groups     = var.alarm_rule_contact_groups
   silence_time       = var.alarm_rule_silence_time
   effective_interval = var.alarm_rule_effective_interval
@@ -78,11 +124,34 @@ resource "alicloud_cms_alarm" "disk_utilization" {
     instanceId = local.this_instance_id
     device     = "/dev/vda1,/dev/vdb1"
   }
-  statistics         = var.alarm_rule_statistics
+  dynamic "escalations_critical" {
+    for_each = var.alarm_escalation_level == "critical" ? [{}] : []
+    content {
+      statistics          = var.alarm_rule_statistics
+      comparison_operator = var.alarm_rule_comparison_operator
+      threshold           = var.alarm_rule_threshold
+      times               = var.alarm_rule_times
+    }
+  }
+  dynamic "escalations_warn" {
+    for_each = var.alarm_escalation_level == "warn" ? [{}] : []
+    content {
+      statistics          = var.alarm_rule_statistics
+      comparison_operator = var.alarm_rule_comparison_operator
+      threshold           = var.alarm_rule_threshold
+      times               = var.alarm_rule_times
+    }
+  }
+  dynamic "escalations_info" {
+    for_each = var.alarm_escalation_level == "info" ? [{}] : []
+    content {
+      statistics          = var.alarm_rule_statistics
+      comparison_operator = var.alarm_rule_comparison_operator
+      threshold           = var.alarm_rule_threshold
+      times               = var.alarm_rule_times
+    }
+  }
   period             = var.alarm_rule_period
-  operator           = var.alarm_rule_operator
-  threshold          = var.alarm_rule_threshold
-  triggered_count    = var.alarm_rule_triggered_count
   contact_groups     = var.alarm_rule_contact_groups
   silence_time       = var.alarm_rule_silence_time
   effective_interval = var.alarm_rule_effective_interval
@@ -97,11 +166,34 @@ resource "alicloud_cms_alarm" "intranet_in" {
     instanceId = local.this_instance_id
     device     = "/dev/vda1,/dev/vdb1"
   }
-  statistics         = var.alarm_rule_statistics
+  dynamic "escalations_critical" {
+    for_each = var.alarm_escalation_level == "critical" ? [{}] : []
+    content {
+      statistics          = var.alarm_rule_statistics
+      comparison_operator = var.alarm_rule_comparison_operator
+      threshold           = var.alarm_rule_threshold
+      times               = var.alarm_rule_times
+    }
+  }
+  dynamic "escalations_warn" {
+    for_each = var.alarm_escalation_level == "warn" ? [{}] : []
+    content {
+      statistics          = var.alarm_rule_statistics
+      comparison_operator = var.alarm_rule_comparison_operator
+      threshold           = var.alarm_rule_threshold
+      times               = var.alarm_rule_times
+    }
+  }
+  dynamic "escalations_info" {
+    for_each = var.alarm_escalation_level == "info" ? [{}] : []
+    content {
+      statistics          = var.alarm_rule_statistics
+      comparison_operator = var.alarm_rule_comparison_operator
+      threshold           = var.alarm_rule_threshold
+      times               = var.alarm_rule_times
+    }
+  }
   period             = var.alarm_rule_period
-  operator           = var.alarm_rule_operator
-  threshold          = var.alarm_rule_threshold
-  triggered_count    = var.alarm_rule_triggered_count
   contact_groups     = var.alarm_rule_contact_groups
   silence_time       = var.alarm_rule_silence_time
   effective_interval = var.alarm_rule_effective_interval
@@ -116,11 +208,34 @@ resource "alicloud_cms_alarm" "intranet_out" {
     instanceId = local.this_instance_id
     device     = "/dev/vda1,/dev/vdb1"
   }
-  statistics         = var.alarm_rule_statistics
+  dynamic "escalations_critical" {
+    for_each = var.alarm_escalation_level == "critical" ? [{}] : []
+    content {
+      statistics          = var.alarm_rule_statistics
+      comparison_operator = var.alarm_rule_comparison_operator
+      threshold           = var.alarm_rule_threshold
+      times               = var.alarm_rule_times
+    }
+  }
+  dynamic "escalations_warn" {
+    for_each = var.alarm_escalation_level == "warn" ? [{}] : []
+    content {
+      statistics          = var.alarm_rule_statistics
+      comparison_operator = var.alarm_rule_comparison_operator
+      threshold           = var.alarm_rule_threshold
+      times               = var.alarm_rule_times
+    }
+  }
+  dynamic "escalations_info" {
+    for_each = var.alarm_escalation_level == "info" ? [{}] : []
+    content {
+      statistics          = var.alarm_rule_statistics
+      comparison_operator = var.alarm_rule_comparison_operator
+      threshold           = var.alarm_rule_threshold
+      times               = var.alarm_rule_times
+    }
+  }
   period             = var.alarm_rule_period
-  operator           = var.alarm_rule_operator
-  threshold          = var.alarm_rule_threshold
-  triggered_count    = var.alarm_rule_triggered_count
   contact_groups     = var.alarm_rule_contact_groups
   silence_time       = var.alarm_rule_silence_time
   effective_interval = var.alarm_rule_effective_interval

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,12 @@ variable "enable_alarm_rule" {
   default     = true
 }
 
+variable "alarm_escalation_level" {
+  description = "Whether alarm level is 'critical', 'warn', or 'info'. Default is 'critical'."
+  type        = string
+  default     = "critical"
+}
+
 variable "alarm_rule_name" {
   description = "The alarm rule name. "
   type        = string
@@ -52,7 +58,7 @@ variable "alarm_rule_statistics" {
   default     = "Average"
 }
 
-variable "alarm_rule_operator" {
+variable "alarm_rule_comparison_operator" {
   description = "Alarm comparison operator. Valid values: ['<=', '<', '>', '>=', '==', '!=']. Default to '=='. "
   type        = string
   default     = "=="
@@ -64,7 +70,7 @@ variable "alarm_rule_threshold" {
   default     = ""
 }
 
-variable "alarm_rule_triggered_count" {
+variable "alarm_rule_times" {
   description = "Number of consecutive times it has been detected that the values exceed the threshold. Default to 3. "
   type        = number
   default     = 3


### PR DESCRIPTION
Currently using the module with provider version > 1.94.0 produces deprecation warnings:
```
Warning: "operator": [DEPRECATED] Field 'operator' has been deprecated from provider version 1.94.0. New field 'escalations_critical.comparison_operator' instead.

Warning: "statistics": [DEPRECATED] Field 'statistics' has been deprecated from provider version 1.94.0. New field 'escalations_critical.statistics' instead.

Warning: "triggered_count": [DEPRECATED] Field 'triggered_count' has been deprecated from provider version 1.94.0. New field 'escalations_critical.times' instead.

Warning: "threshold": [DEPRECATED] Field 'threshold' has been deprecated from provider version 1.94.0. New field 'escalations_critical.threshold' instead.
```
This MR replaces these fields with the newer `escalations_critical`, `escalations_warn`, and `escalations_info` blocks.